### PR TITLE
Add @return to docblock

### DIFF
--- a/src/ServiceDirectory.php
+++ b/src/ServiceDirectory.php
@@ -93,6 +93,8 @@ class ServiceDirectory
 
     /**
      * Fetch all service descriptions.
+     *
+     * @return Service[]
      */
     public function getAllServiceDescriptions()
     {


### PR DESCRIPTION
This way people using proper IDE like PhpStorm will get hinting.
```
$services = $dir->getAllServiceDescriptions();
// IDE knows that each element of services array is an instance of Service class.
$services[0]->toArray();
```